### PR TITLE
Add `focus_id` pipe

### DIFF
--- a/README.md
+++ b/README.md
@@ -61,6 +61,12 @@ Focus on a pane by index:
 zellij pipe "zjpane::focus_at::PANE_INDEX"
 ```
 
+Focus on a pane by id (based on the `ZELLIJ_PANE_ID` environment variable):
+
+```
+zellij pipe "zjpane::focus_id::PANE_ID"
+```
+
 Execute a command by name:
 
 ```

--- a/src/main.rs
+++ b/src/main.rs
@@ -215,6 +215,13 @@ impl State {
                     focus_terminal_pane(pane.id, false);
                 }
             }
+            "focus_id" => {
+                if let Ok(pane_id) = payload.parse::<u32>() {
+                    if let Some(pane) = self.panes.iter().find(|p| p.id == pane_id) {
+                        focus_terminal_pane(pane.id, false);
+                    }
+                }
+            }
             "focus" => {
                 let pane = self.panes.iter_mut().find(|pane| pane.title.eq(payload));
                 if let Some(pane) = pane {


### PR DESCRIPTION
The `focus_at` pipe checks the pane number against in the index of panes, but this sometimes doesnt align with the `ZELLIJ_PANE_ID` environment variable of the pane.  For example, creating a floating pane quickly means that pane index != pane id.

This PR just adds another pipe option, which matches to `ZELLIJ_PANE_ID`. 

This makes it super useful for creating "send to REPL" type pipes inside Helix :)

Thanks for the plugin!